### PR TITLE
fix: return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-git-lastmod",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gatsby plugin that adds lastmod field to pages based on git commit data",
   "license": "MIT",
   "homepage": "https://github.com/vondenstein/gatsby-plugin-git-lastmod",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -28,7 +28,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
     lastMod = new Date().toISOString()
   }
 
-  createPage({
+  return createPage({
     ...page,
     context: {
       ...page.context,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -11,10 +11,8 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   const { createPage } = actions
 
-  /***
-   * Add last modified date for sitemap using component name
-   * unless it is an mdx blog post, in which case use contentFilePath
-   ***/
+  // Add last modified date for sitemap using component name
+  // unless it is an mdx blog post, in which case use contentFilePath
   const filePath = page.component.split("?__contentFilePath=").pop()
   const fileLog = await simpleGit().log({
     file: filePath,


### PR DESCRIPTION
<!-- Note: please make use of Conventional Commit messages, as they are used for generating changelogs. You can learn more about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

Fixed return type for `onCreatePages` to report proper status during Gatsby build process.