### PR TITLE
chore: added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+# Dependency directories
+node_modules
+src
+
+# Node files
+package-lock.json
+
+# GitHub files
+.github
+
+# Auto-Formatter files
+.prettierignore
+.prettierrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-plugin-git-lastmod",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-plugin-git-lastmod",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "simple-git": "^3.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-git-lastmod",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Gatsby plugin that adds lastmod field to pages based on git commit data",
   "license": "MIT",
   "homepage": "https://github.com/vondenstein/gatsby-plugin-git-lastmod",


### PR DESCRIPTION
<!-- Note: please make use of Conventional Commit messages, as they are used for generating changelogs. You can learn more about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

Added `.npmignore` to control which files are published to npmjs